### PR TITLE
Update fedora builders

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -105,7 +105,10 @@ mybuilders.append("opensuse12-x86_64-builder")
 mybuilders.append("ubuntu14-x86_64-builder")
 mybuilders.append("solaris10_x86-builder") 
 mybuilders.append("solaris11_x86-builder") 
-mybuilders.append("fedora20-x86_64-builder") 
+mybuilders.append("fedora21-x86_64-builder")
+mybuilders.append("fedora22-x86_64-builder")
+mybuilders.append("fedora23-x86_64-builder")
+mybuilders.append("fedora24-x86_64-builder")
 
 devel17_builders = []
 
@@ -123,10 +126,6 @@ semidaily_builders.append("irix-builder")
 
 # builders for the master daily builds
 semidaily_master_builders = []
-semidaily_master_builders.append("fedora21-x86_64-builder") 
-semidaily_master_builders.append("fedora22-x86_64-builder") 
-semidaily_master_builders.append("fedora23-x86_64-builder") 
-semidaily_master_builders.append("fedora24-x86_64-builder")
 semidaily_master_builders.append("fedora25-x86_64-builder")
 semidaily_master_builders.append("rhel5-x86_64-builder") 
 semidaily_master_builders.append("rhel6-x86_64-builder") 


### PR DESCRIPTION
Take the fedora20 builder out of any triggered builds as it is
believed to be decomissioned.  Add the fedora21-24 builders to
the triggered builds in its place (fedora25 is not ready yet).