### PR TITLE
Experiment with not using make -j for tumbleweed

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -403,8 +403,8 @@ susefactory64.addStep(ShellCommand(command=["git","gc","--auto"],timeout=3600))
 susefactory64.addStep(ShellCommand(command=["git","clean","-X","-f","-e","!.buildbot-sourcedata"]))
 susefactory64.addStep(ShellCommand(command=["sh","regen.sh"],timeout=3600))
 susefactory64.addStep(Configure(command=["./configure","--enable-checking","--enable-supergroups","--enable-namei-fileserver","--enable-pthreaded-ubik","--with-linux-kernel-build=/usr/src/linux-obj/x86_64/default"]))
-susefactory64.addStep(Compile(command=["make","-j4"]))
-susefactory64.addStep(Compile(command=["make","-j4","dest"]))
+susefactory64.addStep(Compile(command=["make"]))
+susefactory64.addStep(Compile(command=["make","dest"]))
 
 ######### opensuse12 builder
 opensuse12_x86_builder = {'name': "opensuse12-i386-builder",


### PR DESCRIPTION
The opensuse-tumbleweed builds have ~always been failing with
a segfault from swig (builting the uafs bindings).  Supposedly
swig-pl is incompatible with parallel make, so maybe doing things
serially will let things get farther.  It's probably worth a try,
but expect this to be reverted later on.