### PR TITLE
limit win7-amd64 builder to two simultaneous builds

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -36,6 +36,7 @@ c['protocols'] = {'pb': {'port': 9989}}
 
 worker_config = {
     'linux-rc-x86_64': dict(max_builds=1),
+    'win7-amd64': dict(max_builds=2),
 }
 
 c['workers'] = []


### PR DESCRIPTION
The VM hosting this builder only has two vcpu, and the build is CPU
bound, so more simultaneous builds slows everything down.