### PR TITLE
Fix incorrect patchset being selected with ForceGerritBuild

### DIFF
--- a/files/forcegerritbuild.py
+++ b/files/forcegerritbuild.py
@@ -158,7 +158,7 @@ class ForceGerritBuild(schedulers.ForceScheduler):
             collector.setFieldName("patchsetnumber")
             UI_patchset = properties.getProperty("patchsetnumber")
             patchsets = gerritinfo['patchSets']
-            patchset = max(patchsets, key=lambda item: item['number'])
+            patchset = str(max(patchsets, key=lambda item: int(item['number'])))
 
             if UI_patchset is not None and UI_patchset != '':
                 patchset = None


### PR DESCRIPTION
The list of patchset numbers returned from gerrit are strings.  When
obtaining the most current (highest number), the test was performing a
string comparision so '9' was being selected as bigger than '10'

i.e. max(['1','10','9']) returns '9'

Update to convert the patchset numbers to int while finding the highest
patchset number.