### PR TITLE
Gerrit returns patchset number as str or int

### DIFF
--- a/files/forcegerritbuild.py
+++ b/files/forcegerritbuild.py
@@ -164,7 +164,7 @@ class ForceGerritBuild(schedulers.ForceScheduler):
                 patchset = None
                 UI_patchset = int(UI_patchset)
                 for ps in gerritinfo['patchSets']:
-                    if ps['number'] == UI_patchset:
+                    if int(ps['number']) == UI_patchset:
                         patchset = ps
 
                 if patchset is None:
@@ -219,8 +219,8 @@ class ForceGerritBuild(schedulers.ForceScheduler):
                 'project': project
             }
         ]
-        log.msg("forcegerritbuild: rebuilding branch[%s] revision[%s] project[%s] event.change.id[%s] patchset[%d]" %
-                (patchset['ref'], patchset['revision'], project, changeid, patchset['number']))
+        log.msg("forcegerritbuild: rebuilding branch[%s] revision[%s] project[%s] event.change.id[%s] patchset[%s]" %
+                (patchset['ref'], patchset['revision'], project, changeid, str(patchset['number'])))
         # everything is set and validated, we can create our source stamp, and
         # buildrequest
         res = yield self.addBuildsetForSourceStampsWithDefaults(


### PR DESCRIPTION
Depending on the version of gerrit, the returned
value for the patch set number can be either a str or an int.

Force the conversion of the patchset number as needed.