### PR TITLE
Fix syntax error in forcegerritbuild

### DIFF
--- a/files/forcegerritbuild.py
+++ b/files/forcegerritbuild.py
@@ -184,7 +184,7 @@ class ForceGerritBuild(schedulers.ForceScheduler):
 
             builderNames = self.branchbuilders[branch]
             if not builderNames:
-                log.msg("forcegerritbuild: empty builders for branch: %s" (branch,))
+                log.msg("forcegerritbuild: empty builders for branch: %s" % (branch,))
                 raise ValidationError("Empty builders for branch %s" % (branch,))
 
             # Set the properties neede by GerritStatusPush reporter


### PR DESCRIPTION
Add missing '%' between a string and the substitution variables.

This is now being flagged as a syntax error after an upgrade of the
buildbot master (newer level of python).