### PR TITLE
Add WatchedWorker class to monitor unavailable workers

### DIFF
--- a/files/watchedworker.py
+++ b/files/watchedworker.py
@@ -1,0 +1,99 @@
+{% raw %}
+
+from twisted.internet import defer
+from buildbot.worker import AbstractLatentWorker
+from buildbot.data import resultspec
+from buildbot.process.results import EXCEPTION
+from buildbot.process.results import CANCELLED
+import time
+
+class WatchedWorker(AbstractLatentWorker):
+    """
+        Worker class that cancels builds if a worker times out
+    """
+    start_missing_on_startup = True
+    def __init__(self, name, password, missing_timeout=120, **kwargs):
+        self.triedstart = 0
+        self.timedout = False
+        super().__init__(name, password,
+                         build_wait_timeout=-1,
+                         missing_timeout=missing_timeout,
+                         **kwargs)
+
+    @defer.inlineCallbacks
+    def start_instance(self, build):
+        """
+            Creating new worker instance
+        """
+        self.timedout = False
+        self.triedstart += 1
+        ret = yield True
+        return ret
+
+    def stop_instance(self, fast=False):
+        """
+            Shutting down a worker instance
+        """
+        self.stopMissingTimer()
+        self.timedout = False
+        self.triedstart = 0
+        return True
+
+    @defer.inlineCallbacks
+    def _cancelbuilds(self):
+        """
+            Mark any active builds on this worker as build exceptions
+        """
+        if not self.timedout and self.triedstart <= 2:
+            return
+
+        self.stopMissingTimer()
+        self.timedout = False
+        self.triedstart = 0
+        self.quarantine_timeout = self.quarantine_initial_timeout
+
+        # cancel all buildrequests for this worker because it's not available
+        for wfb in self.workerforbuilders.values():
+            for build in wfb.builder.building:
+                yield build.buildException("cancelled because worker timeout")
+
+        for wfb in self.workerforbuilders.values():
+            yield wfb.buildFinished()
+        yield self.botmaster.maybeStartBuildsForWorker(self.name)
+
+    def buildStarted(self, wfb):
+        """
+            When a build starts, start the watchdog
+        """
+        self.startMissingTimer()
+        return super().buildStarted(wfb)
+
+    def messageReceivedFromWorker(self):
+        """
+            Any response from the worker cancels the timeout
+
+            If we want cancel a build when a step within a worker has
+            "stopped" or gotten hung up, we can change this around to keep
+            the watchdog timer going and just have a flag here that is reset.
+
+        """
+        self.stopMissingTimer()
+        self.timedout = False
+        self.triedstart = 0
+        return super().messageReceivedFromWorker()
+
+    def _missing_timer_fired(self):
+        """
+            Timeout fired .. cancel any active builds for this worker.
+
+            If we want to cancel a build when a step within a builder has
+            "stopped" or gotten hung up, we can change this around to watch
+            a flag set in messageReceivedFromWorker
+        """
+        self.missing_timer = None
+        self.timedout = True
+        if not self.parent:
+            return
+        self._cancelbuilds()
+
+{% endraw %}

--- a/inventory/openafs/host_vars/buildbot.openafs.org.yaml
+++ b/inventory/openafs/host_vars/buildbot.openafs.org.yaml
@@ -16,6 +16,7 @@ buildbot_master_config_files:
   - "{{ playbook_dir }}/files/forcegerritbuild.py"
   - "{{ playbook_dir }}/files/email_templates.py"
   - "{{ playbook_dir }}/files/passwords.ini"
+  - "{{ playbook_dir }}/files/watchedworker.py"
 afsbotcfg_title: "The OpenAFS Buildbot Coordinator"
 afsbotcfg_url: "https://buildbot.openafs.org/"
 afsbotcfg_repo: "https://gerrit.openafs.org/openafs.git"


### PR DESCRIPTION
If a worker is unavailable, buildbot will not complete the report back
to gerrit.

Provide facility that will cancel a build job on a worker that is not
available.

Buildbot provides a python class, AbstractLatentWorker, for workers
that are created/destroyed on virtual hosts.  Part of this class is
support for handling worker timeouts.

Use the AbstractLatentWorker class to create a "WatchedWorker" class.

This class setups up a watchdog timer and will monitor for the actual
start of build steps. The watchdog timer is started when the build
starts and is turned off when any message is received from the worker.

To use this class:

add an import for watchedworker and use the watchedworker.WatchedWorker
instead of the worker.Worker class.

The length of time for the watchdog timer is controlled via the
missing_timeout keyword parameter (default set to 120 seconds).  The
length of the time needs to be sufficient to allow the worker to start
doing work, yet not too long as to hold up other builds.

When a build is cancelled, the final result status will be "exception"

Note:

It was determined that a build must be first started before it can be
cancelled so that the GerritStatusPush callback is invoked correctly.