### PR TITLE
Upgrade to Buildbot 3.5.0

### DIFF
--- a/files/master.cfg
+++ b/files/master.cfg
@@ -7,6 +7,7 @@ import configparser
 import datetime
 from buildbot.plugins import changes
 from buildbot.plugins import reporters
+from buildbot.reporters.generators.build import BuildStatusGenerator
 from buildbot.plugins import schedulers
 from buildbot.plugins import steps
 from buildbot.plugins import util
@@ -581,17 +582,20 @@ c['services'] = [
     ),
     reporters.MailNotifier(
         fromaddr='buildbot@openafs.MIT.EDU',
-        builders=['linux-rc-x86_64'],
-        mode=['failing', 'passing'],
+        generators=[
+            BuildStatusGenerator(
+                builders=['linux-rc-x86_64'],
+                mode=['failing', 'passing'],
+                message_formatter=reporters.MessageFormatter(
+                    template=email_templates.body)
+                )
+        ],
         sendToInterestedUsers=False,
         extraRecipients=[
             'mmeffie@sinenomine.net',
             'mvitale@sinenomine.net',
             'stephan.wiesand@desy.de',
         ],
-        messageFormatter=reporters.MessageFormatter(
-            template=email_templates.body,
-        ),
     ),
 ]
 

--- a/inventory/openafs/host_vars/buildbot.openafs.org.yaml
+++ b/inventory/openafs/host_vars/buildbot.openafs.org.yaml
@@ -4,7 +4,7 @@ ansible_user: buildbot
 buildbot_project: openafs
 buildbot_master_have_sudo: no
 buildbot_master_sqlalchemy_version: '==1.3.17'
-buildbot_master_buildbot_version: '==2.8.4'
+buildbot_master_buildbot_version: '==2.10.0'
 buildbot_master_python: "/opt/rh/rh-python36/root/usr/bin/python3.6"
 buildbot_master_basedir: "/home/buildbot/master/openafs"
 buildbot_master_gerrit_ident: gerrit

--- a/inventory/openafs/host_vars/buildbot.openafs.org.yaml
+++ b/inventory/openafs/host_vars/buildbot.openafs.org.yaml
@@ -3,8 +3,8 @@
 ansible_user: buildbot
 buildbot_project: openafs
 buildbot_master_have_sudo: no
-buildbot_master_sqlalchemy_version: '==1.3.17'
-buildbot_master_buildbot_version: '==2.10.0'
+buildbot_master_sqlalchemy_version: '==1.4.28'
+buildbot_master_buildbot_version: '==3.5.0'
 buildbot_master_python: "/opt/rh/rh-python36/root/usr/bin/python3.6"
 buildbot_master_basedir: "/home/buildbot/master/openafs"
 buildbot_master_gerrit_ident: gerrit

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -30,8 +30,8 @@ provisioner:
         buildbot_master_gerrit_ident: ${MOLECULE_PROJECT_DIRECTORY}/files/gerrit
         buildbot_master_gerrit_hostkey: ${MOLECULE_PROJECT_DIRECTORY}/files/gerrit.hostkey
         buildbot_master_have_sudo: yes
-        buildbot_master_sqlalchemy_version: '==1.3.17'
-        buildbot_master_buildbot_version: '==2.10.0'
+        buildbot_master_sqlalchemy_version: '==1.4.28'
+        buildbot_master_buildbot_version: '==3.5.0'
         buildbot_master_config_files:
           - ${MOLECULE_PROJECT_DIRECTORY}/files/master.cfg
           - ${MOLECULE_PROJECT_DIRECTORY}/files/settings.py

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -31,7 +31,7 @@ provisioner:
         buildbot_master_gerrit_hostkey: ${MOLECULE_PROJECT_DIRECTORY}/files/gerrit.hostkey
         buildbot_master_have_sudo: yes
         buildbot_master_sqlalchemy_version: '==1.3.17'
-        buildbot_master_buildbot_version: '==2.8.4'
+        buildbot_master_buildbot_version: '==2.10.0'
         buildbot_master_config_files:
           - ${MOLECULE_PROJECT_DIRECTORY}/files/master.cfg
           - ${MOLECULE_PROJECT_DIRECTORY}/files/settings.py

--- a/molecule/master-only/molecule.yml
+++ b/molecule/master-only/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
         buildbot_master_gerrit_hostkey: ${MOLECULE_PROJECT_DIRECTORY}/files/gerrit.hostkey
         buildbot_master_have_sudo: yes
         buildbot_master_sqlalchemy_version: '==1.3.17'
-        buildbot_master_buildbot_version: '==2.8.4'
+        buildbot_master_buildbot_version: '==2.10.0'
         buildbot_master_config_files:
           - ${MOLECULE_PROJECT_DIRECTORY}/files/master.cfg
           - ${MOLECULE_PROJECT_DIRECTORY}/files/settings.py

--- a/molecule/master-only/molecule.yml
+++ b/molecule/master-only/molecule.yml
@@ -22,8 +22,8 @@ provisioner:
         buildbot_master_gerrit_ident: ${MOLECULE_PROJECT_DIRECTORY}/files/gerrit
         buildbot_master_gerrit_hostkey: ${MOLECULE_PROJECT_DIRECTORY}/files/gerrit.hostkey
         buildbot_master_have_sudo: yes
-        buildbot_master_sqlalchemy_version: '==1.3.17'
-        buildbot_master_buildbot_version: '==2.10.0'
+        buildbot_master_sqlalchemy_version: '==1.4.28'
+        buildbot_master_buildbot_version: '==3.5.0'
         buildbot_master_config_files:
           - ${MOLECULE_PROJECT_DIRECTORY}/files/master.cfg
           - ${MOLECULE_PROJECT_DIRECTORY}/files/settings.py


### PR DESCRIPTION
Upgrade to latest buildbot version 3.4.1
Upgrade sqlalchemy to 1.4.28


Update master.cfg to handle new 3.x difference with the changes to the
MailNotifier reporter.


The path to fix buildbot issue 5190 is no longer needed.
 set buildbot_master_patch to no

Add the collections.yml file to the default molecule scenario.

To perform actual upgrade, installer will need to override the
buildbot_master_install value from no to yes in for the host vars
for buildbot.openafs.org