### PR TITLE
Use GerritChangeFilter

### DIFF
--- a/files/master.cfg
+++ b/files/master.cfg
@@ -431,9 +431,10 @@ def add_gerrit_scheduler(branch):
         raise ValueError('Unknown branch name: %s' % branch)
     c['schedulers'].append(schedulers.SingleBranchScheduler(
         name='gerrit-' + branch,
-        change_filter=util.ChangeFilter(
+        change_filter=util.GerritChangeFilter(
             project='openafs',
-            branch_re='^{0}/.*'.format(branch),
+            branch=branch,
+            eventtype="patchset-created"
         ),
         treeStableTimer=None, # Schedule immediately to build all changes.
         builderNames=scheduled('gerrit', branch),


### PR DESCRIPTION
The format of the branch name handed to the change filter was changed
in the builtbot upgrade.

Use the GerritChangeFilter handle the filtering for the gerrit
schedulers as it understands the branch name from gerrit.