### PR TITLE
add notify_on_missing for the workers

### DIFF
--- a/files/master.cfg
+++ b/files/master.cfg
@@ -8,6 +8,7 @@ import datetime
 from buildbot.plugins import changes
 from buildbot.plugins import reporters
 from buildbot.reporters.generators.build import BuildStatusGenerator
+from buildbot.reporters.generators.worker import WorkerMissingGenerator
 from buildbot.plugins import schedulers
 from buildbot.plugins import steps
 from buildbot.plugins import util
@@ -16,6 +17,19 @@ from buildbot.plugins import worker
 import settings
 import email_templates
 import forcegerritbuild
+
+class WorkerAdmins:
+# Mapper of worker to admins
+    def __init__(self):
+        self.workertable = {}
+    def add_admin(self, admin, workerlist):
+        for worker in workerlist:
+            self.workertable[worker] = admin
+    def get_admin(self,worker):
+        try:
+            return self.workertable[worker]
+        except KeyError:
+            return None
 
 BuildmasterConfig = c = {}
 
@@ -44,9 +58,66 @@ c['buildbotNetUsageData'] = None # Disable phone-home feature.
 
 c['protocols'] = {'pb': {'port': 9989}}
 
+workeradmins = WorkerAdmins()
+workeradmins.add_admin("mmeffie@sinenomine.net",
+                       ["centos7-arm64",
+                        "centos73-x86_64",
+                        "centos8-amd64",
+                        "debian87-x86_64",
+                        "debian9-amd64",
+                        "debian10-amd64",
+                        "debian11-amd64",
+                        "opensuse12-x86_64",
+                        "opensuse15-arm64",
+                        "sol11sparc",
+                        "solaris114-x86-2",
+                        "sun510_x86",
+                        "ubuntu1610-x86_64",
+                        "ubuntu1804-amd64",
+                        "ubuntu2004-amd64"])
+workeradmins.add_admin("derek@ihtfp.com",
+                       ["fedora20-x86_64",
+                        "fedora21-x86_64",
+                        "fedora22-x86_64",
+                        "fedora23-x86_64",
+                        "fedora24-x86_64",
+                        "fedora25-x86_64",
+                        "fedora26-x86_64",
+                        "fedora27-x86_64",
+                        "fedora28-x86_64",
+                        "fedora29-x86_64",
+                        "fedora30-x86_64",
+                        "fedora31-x86_64",
+                        "fedora32-x86_64",
+                        "fedora33-x86_64",
+                        "fedora34-x86_64",
+                        "fedora35-x86_64"])
+
+workeradmins.add_admin("mbarbosa@sinenomine.net",
+                       ["macos10-13-x86_64",
+                        "macos10-14-x86_64",
+                        "macos10-15-x86_64"])
+
+workeradmins.add_admin("cwills@sinenomine.net",
+                       ["gentoo-gcc-amd64",
+                        "gentoo-amd64"])
+workeradmins.add_admin("mansaxel@besserwisser.org",
+                       ["freebsd12-amd64"])
+workeradmins.add_admin("asedeno@mit.edu",
+                       ["wins2019-amd64"])
+{% endraw %}
+{% if buildbot_test is defined %}
+# Don't spam admins when testing
+workeradmins = WorkerAdmins()
+workeradmins.add_admin("root@localhost",
+                       ["centos73-x86_64",
+                        "debian10-amd64"])
+{% endif %}
+{% raw %}
 c['workers'] = []
 for name, password in passwords.items('workers'):
-    c['workers'].append(worker.Worker(name, password))
+    c['workers'].append(worker.Worker(name, password,
+                                      notify_on_missing=workeradmins.get_admin(name)))
 
 ####### CHANGESOURCES
 
@@ -580,6 +651,12 @@ c['services'] = [
         port=29418,
         identity_file=os.path.expanduser('~/.ssh/gerrit'),
         summaryCB=gerrit_summary_callback,
+    ),
+    reporters.MailNotifier(
+        fromaddr='buildbot@openafs.MIT.EDU',
+        generators=[
+            WorkerMissingGenerator(workers="all")
+        ]
     ),
     reporters.MailNotifier(
         fromaddr='buildbot@openafs.MIT.EDU',

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,6 +23,7 @@ provisioner:
   inventory:
     group_vars:
       all:
+        buildbot_test : true
         buildbot_project: openafs
         passwords_ini: ${MOLECULE_PROJECT_DIRECTORY}/files/passwords.ini
         ansible_shell_allow_world_readable_temp: true

--- a/molecule/master-only/molecule.yml
+++ b/molecule/master-only/molecule.yml
@@ -15,6 +15,7 @@ provisioner:
   inventory:
     group_vars:
       all:
+        buildbot_test : true
         buildbot_project: openafs
         passwords_ini: ${MOLECULE_PROJECT_DIRECTORY}/files/passwords.ini
         ansible_shell_allow_world_readable_temp: true


### PR DESCRIPTION
Set up the notify_on_missing facility to detect when a worker is not
available.  If a worker is "disconnected" for over 1 hour (the default
missing_timeout), one email will be sent to the "administrator" for that
worker.

Builds scheduled for these workers will remain in a "pending" state
until the worker reconnects.

Note if the buildbot master is restarted, the missing worker detection
is reset and emails will be resent for any missing workers.

Add the workers with their associated admins (admin emails obtained from
the current worker info)

When testing, the list of defined workers will be detected as missing.
To avoid sending emails to the admins while testing, define the ansible
variable "buildbot_test" in the molecule group vars.