### PR TITLE
Fix shell cmd syntax error and make the step idempotent

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -45,7 +45,11 @@
 
     - name: Disable certificate checking
       become: yes
-      shell: "sudo -u buildbot git --global http.sslVerify=false"
+      become_user: buildbot
+      git_config:
+         scope: global
+         name: http.sslVerify
+         value: false
 
 - name: Finish up master setup
   hosts: openafs_buildbot_masters


### PR DESCRIPTION
The "Disable certificate checking" step in the default converge fails
with a syntax error in the git command.  In addition the step will
always register a change since it's using "shell".

Make the "Disable certificate checking" idempotent by using "git_config"
instead of "shell" for the step.  This also fixes the command syntax
error.