### PR TITLE
Sort and categorize buildbot results for gerrit

### DIFF
--- a/files/master.cfg
+++ b/files/master.cfg
@@ -636,31 +636,67 @@ c['schedulers'].append(forcegerritbuild.ForceGerritBuild(
 ####### BUILDBOT SERVICES
 
 def gerrit_summary_callback(buildInfoList, results, status, arg):
-    success = False
-    failure = False
-    msgs = [settings.summary_title, settings.buildbotURL]
-    for buildInfo in buildInfoList:
-        msg = "Builder %(name)s %(resultText)s (%(text)s)" % buildInfo
-        if settings.buildbotURL:
-            link = buildInfo.get('url', None)
-            if link:
-                msg += " - " + link
-            else:
-                msg += "."
-        else:
+
+    def report_build_status(buildlist, finalstatus=None):
+        for info in buildlist:
+            msg = "    Builder %(name)s %(resultText)s (%(text)s)" % info
+            if settings.buildbotURL:
+                link = info.get('url', None)
+                if link:
+                    msg += " - " + link
+            if finalstatus:
+                msg += "\n       Final build status %(resultText)s" % finalstatus[info['name']]
             msg += "."
-        msgs.append(msg)
-        if buildInfo['result'] == util.SUCCESS:
-            success = True
-        else:
-            failure = True
+            yield msg
+
+    msgs = [settings.summary_title, settings.buildbotURL]
+
+    # sort buildinfo by builder and completed build time
+    # we want to get the final result of any particular builder
+    # in case there was a retry that ended up with a successful build
+    buildInfoList.sort(key=lambda buildinfo:
+        (buildinfo['name'], buildinfo['build']['complete_at']))
+
+    builderFinalStatus = dict()
+    for buildInfo in buildInfoList:
+        builderFinalStatus[buildInfo['name']] = buildInfo
+
+    # Possible results: SUCCESS WARNINGS FAILURE SKIPPED EXCEPTION RETRY CANCELLED
+    successfulBuilds = [fstatus for fstatus in builderFinalStatus.values()
+                            if fstatus['result'] == util.SUCCESS]
+    failedBuilds = [fstatus for fstatus in builderFinalStatus.values()
+                        if fstatus['result'] != util.SUCCESS]
+
+    # typically retries or interrupted builds
+    restartedBuilds = [buildinfo for buildinfo in buildInfoList
+                        if buildinfo not in successfulBuilds and
+                           buildinfo not in failedBuilds]
+
+    msgs.append("Final Build Status (failed %d succeeded %d):" %
+                (len(failedBuilds), len(successfulBuilds)))
+
+    if len(failedBuilds) > 0:
+        msgs.append("\n Failed Builds:")
+        msgs.extend(report_build_status(failedBuilds))
+
+    if len(successfulBuilds) > 0:
+        msgs.append("\n Successful Builds:")
+        msgs.extend(report_build_status(successfulBuilds))
+
+    if len(restartedBuilds) > 0:
+        msgs.append("\n Restarted Builds:")
+        msgs.extend(report_build_status(restartedBuilds, finalstatus=builderFinalStatus))
+
     message = '\n\n'.join(msgs)
-    if success and not failure:
+
+    if len(successfulBuilds) != 0 and len(failedBuilds) == 0:
         verified = 1
     else:
         verified = 0
+
     return dict(message=message,
                 labels={'Verified': verified})
+
 c['services'] = []
 c['services'].append(reporters.GerritStatusPush(
         server=settings.gerrit_server,


### PR DESCRIPTION
The report generated by buildbot for gerrit builds mixes the failed
and succeeded builds.  Identifying a failed build requires looking
through the entire report.

Also, any builds that were restarted (due to a buildbot retry) but are
then successful are still counted as a failure.

Update the buildbot config to sort and categorize the build results.
Show the failed (if any) builds first, followed by the successful
builds.  Show any builds that were restarted.