### PR TITLE
Install epel-release when preparing a host

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -14,6 +14,14 @@
         name: firewalld
       when: ansible_os_family == 'RedHat'
 
+    - name: Install epel-release
+      become: yes
+      ansible.builtin.yum:
+        state: present
+        name:
+          - epel-release
+      when: ansible_pkg_mgr == 'yum'
+
     - name: Install required packages
       become: yes
       ansible.builtin.yum:

--- a/molecule/unix-builder/prepare.yml
+++ b/molecule/unix-builder/prepare.yml
@@ -14,6 +14,14 @@
         name: firewalld
       when: ansible_os_family == 'RedHat'
 
+    - name: Install epel-release
+      become: yes
+      ansible.builtin.yum:
+        state: present
+        name:
+          - epel-release
+      when: ansible_pkg_mgr == 'yum'
+
     - name: Install required packages
       become: yes
       ansible.builtin.yum:


### PR DESCRIPTION
Add a step to install the epel repository before installing the required packages.  Some of the required packages are coming from the epel repository (e.g. python3-virtualenv).