### PR TITLE
Revert "Don't build if there are no code changes"

### DIFF
--- a/src/afsbotcfg/gerrit.py
+++ b/src/afsbotcfg/gerrit.py
@@ -17,19 +17,6 @@
 from buildbot.plugins import util
 
 
-class afsChangeFilter(util.GerritChangeFilter):
-    """
-    Extend the ChangeFilter to include a property check
-    to ignore builds if there were no code changes
-    """
-
-    def __init__(self, **kw):
-        super().__init__(**kw)
-        self.checks.update(self.createChecks(
-                            (None, r"(?!NO_CODE_CHANGE)", None,
-                             "prop:event.patchSet.kind")))
-
-
 def summaryCB(buildInfoList, results, status, arg):
 
     def report_build_status(buildlist, finalstatus=None):

--- a/templates/master.cfg.j2
+++ b/templates/master.cfg.j2
@@ -133,7 +133,7 @@ BuildmasterConfig = {
 {% for branch in afsbotcfg_project.branches | d({'dev': 'master'}) %}
         schedulers.SingleBranchScheduler(
             name='gerrit-{{ branch }}',
-            change_filter=afsbotcfg.gerrit.afsChangeFilter(
+            change_filter=util.GerritChangeFilter(
                 project='{{ afsbotcfg_project.name }}',
                 branch='{{ afsbotcfg_project.branches[branch] }}',
                 eventtype='patchset-created',


### PR DESCRIPTION
Due to a limitation with the currently installed version of buildbot, we cannot use a 'NO_CODE_CHANGE' filter at this time.

If a patchset is being built and a "no code change" commit is pushed before the build finishes, the vote from the build is not applied.

NOTE:
When tested with the latest version of Buildbot, this limitation is not present.

This reverts commit 4ed383a07f305ebed77bfbdcb31784bcfdc2a59c.

 Conflicts:
	src/afsbotcfg/gerrit.py  -- Just white space