### PR TITLE
Rewrite build status messages

### DIFF
--- a/src/afsbotcfg/gerrit.py
+++ b/src/afsbotcfg/gerrit.py
@@ -43,7 +43,7 @@ def summaryCB(buildInfoList, results, status, arg):
         builderFinalStatus[buildInfo['name']] = buildInfo
         # Fix up the final status
         if buildInfo['result'] == util.CANCELLED:
-            if buildInfo['text'] == 'build failed due to worker timeout':
+            if buildInfo['text'] == 'build failed due to critical worker timeout':
                 builderFinalStatus[buildInfo['name']]['result'] = util.FAILURE
                 builderFinalStatus[buildInfo['name']]['resultText'] = "cancelled"
             elif buildInfo['text'] == 'build skipped due to worker timeout':
@@ -69,8 +69,14 @@ def summaryCB(buildInfoList, results, status, arg):
         and buildinfo not in skippedBuilds
     ]
 
-    msgs.append("Final Build Status (failed %d succeeded %d skipped %d):" %
-                (len(failedBuilds), len(successfulBuilds), len(skippedBuilds)))
+    if len(successfulBuilds) != 0 and len(failedBuilds) == 0:
+        verified = 1
+    else:
+        verified = 0
+
+    msgs.append("Final Builder Status %s: Succeeded: %d, Failed: %d, Skipped: %d" %
+                "Passed" if verified = 1 else "Failed",
+                (len(successfulBuilds), len(failedBuilds), len(skippedBuilds)))
 
     if len(failedBuilds) > 0:
         msgs.append("\n Failed Builds:")
@@ -89,10 +95,5 @@ def summaryCB(buildInfoList, results, status, arg):
         msgs.extend(report_build_status(skippedBuilds))
 
     message = '\n\n'.join(msgs)
-
-    if len(successfulBuilds) != 0 and len(failedBuilds) == 0:
-        verified = 1
-    else:
-        verified = 0
 
     return dict(message=message, labels={'Verified': verified})

--- a/src/afsbotcfg/watchedworker.py
+++ b/src/afsbotcfg/watchedworker.py
@@ -92,7 +92,7 @@ class WatchedWorker(AbstractLatentWorker):
             for build in wfb.builder.building:
                 log.err("build cancelled because worker timeout")
                 if self.critical:
-                    yield build.buildFinished(["build", "failed due to worker timeout"], CANCELLED)
+                    yield build.buildFinished(["build", "failed due to critical worker timeout"], CANCELLED)
                 else:
                     yield build.buildFinished(["build", "skipped due to worker timeout"], CANCELLED)
 


### PR DESCRIPTION
The messages associated with reporting the build status are confusing.

Update the "Final Build Status" line to remove the parentheses and better associate the labels with their counts.

Update the worker timeout message to indicate that a "critical" worker timed out.