### PR TITLE
Set path to local collections directory for lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,12 @@ LOG=ANSIBLE_LOG_PATH="$(LOGFILE)"
 LOGINFO=$(INFO) "Wrote $(LOGFILE)"
 endif
 
+ifndef ANSIBLE_COLLECTIONS_PATH
+LINT_ANSIBLE_COLLECTIONS_PATH=${PWD}/collections:${HOME}/.ansible/collections:/usr/share/ansible/collections
+else
+LINT_ANSIBLE_COLLECTIONS_PATH=${ANSIBLE_COLLECTIONS_PATH}
+endif
+
 #--------------------------------------------------------------------------------------------------------
 # Setup targets
 #
@@ -122,11 +128,11 @@ getlog: $(AFSBOTCFG_LOGDIR)
 # Test targets
 #
 .PHONY: lint
-lint: $(PACKAGES)
+lint: $(PACKAGES) collections
 	$(INFO) "Running lint checks"
 	$(ACTIVATED) $(MAKE) -C src lint
 	$(ACTIVATED) yamllint $(YAML_FILES)
-	$(ACTIVATED) ansible-lint $(LINT_OPTIONS)
+	$(ACTIVATED) ANSIBLE_COLLECTIONS_PATH="${LINT_ANSIBLE_COLLECTIONS_PATH}" ansible-lint $(LINT_OPTIONS)
 
 .PHONY: test
 test: $(PACKAGES) lint build molecule/$(AFSBOTCFG_MOLECULE_SCENARIO)/molecule.yml


### PR DESCRIPTION
ansible-lint searches the ANSIBLE_COLLECTIONS_PATH for collections.  The default ANSIBLE_COLLECTIONS_PATH only searches in the directories ${HOME}/.ansible/collections and /usr/share/ansible/collections.

In the Makefile, use a new variable 'LINT_ANSIBLE_COLLECTION_PATH' that will be used to set the ANSIBLE_COLLECTIONS_PATH env variable when running ansible-lint.  LINT_ANSIBLE_COLLECTION_PATH will point to the local collection directory as well as the default paths if ANSIBLE_COLLECTIONS_PATH hasn't been set.  Otherwise just use the path specified by ANSIBLE_COLLECTIONS_PATH.